### PR TITLE
feat: support SBE explain plan COMPASS-4606

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14264,6 +14264,12 @@
         "mongodb-url": "^3.0.3"
       }
     },
+    "mongodb-explain-compat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-explain-compat/-/mongodb-explain-compat-1.0.0.tgz",
+      "integrity": "sha512-H48H/rkZvCXiVKLpGmz8VEcZ/24Bi05VYqnCulyyKeYMe6eUxy7HQev0+SqBm/v9X9SQkI800Ipw8zBM4n3VLw==",
+      "dev": true
+    },
     "mongodb-explain-plan-model": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/mongodb-explain-plan-model/-/mongodb-explain-plan-model-0.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "mongodb-ace-mode": "^0.4.1",
     "mongodb-ace-theme-query": "0.0.2",
     "mongodb-data-service": "^16.5.2",
+    "mongodb-explain-compat": "^1.0.0",
     "mongodb-explain-plan-model": "^0.2.3",
     "mongodb-js-precommit": "^2.2.0",
     "mongodb-query-parser": "^2.0.2",

--- a/src/components/explain-json/explain-json.jsx
+++ b/src/components/explain-json/explain-json.jsx
@@ -22,7 +22,7 @@ class ExplainJSON extends Component {
    * @returns {React.Component} The rendered component.
    */
   render() {
-    const doc = new HadronDocument(this.props.rawExplainObject);
+    const doc = new HadronDocument(this.props.rawExplainObject.originalData);
 
     return (
       <div className={classnames(styles['explain-json'])}>

--- a/src/components/explain-json/explain-json.spec.js
+++ b/src/components/explain-json/explain-json.spec.js
@@ -8,7 +8,7 @@ import styles from './explain-json.less';
 
 describe('ExplainJSON [Component]', () => {
   let component;
-  const rawExplainObject = {};
+  const rawExplainObject = { originalData: {} };
   const appRegistry = new AppRegistry();
 
   beforeEach(() => {

--- a/src/modules/explain.js
+++ b/src/modules/explain.js
@@ -2,6 +2,7 @@ import ExplainPlanModel from 'mongodb-explain-plan-model';
 import { defaults, isString, find } from 'lodash';
 import { treeStagesChanged } from 'modules/tree-stages';
 import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
+import convertExplainCompat from 'mongodb-explain-compat';
 
 import EXPLAIN_STATES from 'constants/explain-states';
 
@@ -258,8 +259,9 @@ export const fetchExplainPlan = (query) => {
           return dispatch(explainPlanFetched(explain));
         }
 
-        explain = parseExplainPlan(explain, data);
+        explain = parseExplainPlan(explain, convertExplainCompat(data));
         explain = updateWithIndexesInfo(explain, indexes);
+        explain.rawExplainObject.originalData = data;
 
         dispatch(explainPlanFetched(explain));
         dispatch(treeStagesChanged(explain));


### PR DESCRIPTION
- Use `mongodb-explain-compat` to convert SBE-based explain plans
  into ones that are as close as possible to the current explain
  plan format.
- Start storing the original server response and the parsed explain
  plan separately, so that when we advertise the “raw” JSON to the
  users, they actually get the raw server response instead of the
  compatibility-adjusted one that we use for displaying the tree.

---

Server on the left uses SBE, server on the right doesn’t:

![explain2](https://user-images.githubusercontent.com/899444/108354280-848bb880-71e9-11eb-99f9-3baafe4d579a.png)


<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
